### PR TITLE
fixed bug with empty image-url fields would cause broken images to show up

### DIFF
--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: this.props.image || "http://localhost:3001/placeholder.png",
         tagList: this.props.tagList,
       };
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
